### PR TITLE
Preset Modes Bugfix

### DIFF
--- a/custom_components/infinitive/climate.py
+++ b/custom_components/infinitive/climate.py
@@ -210,7 +210,7 @@ class InfinitiveDevice(ClimateDevice):
     @property
     def preset_modes(self):
         """Return supported preset modes."""
-        _LOGGER.debug("Preset Mode:" + str(self.preset_mode))
+        _LOGGER.debug("Preset Mode: " + str(self.preset_mode))
         return [PRESET_HOME, PRESET_HOLD]
 
     @property

--- a/custom_components/infinitive/climate.py
+++ b/custom_components/infinitive/climate.py
@@ -210,8 +210,8 @@ class InfinitiveDevice(ClimateDevice):
     @property
     def preset_modes(self):
         """Return supported preset modes."""
-        _LOGGER.debug("Preset Mode:" + str(self._preset_mode))
-        return self._preset_mode
+        _LOGGER.debug("Preset Mode:" + str(self.preset_mode))
+        return [PRESET_HOME, PRESET_HOLD]
 
     @property
     def device_state_attributes(self):
@@ -272,6 +272,8 @@ class InfinitiveDevice(ClimateDevice):
             self._fan_mode = FAN_MODE_MAP[self._status['fanMode']]
             if self._status['hold'] is True:
                 self._preset_mode == PRESET_HOLD
+            else:
+                self._preset_mode == PRESET_HOME
             self._stage = self._status['stage']
             self._override_duration = self._status['holdDurationMins']
             self._airflow_cfm = self._status['airFlowCFM']


### PR DESCRIPTION
The preset_modes property is supposed to return a list of available presets but was instead returning just the singular self._preset_mode internal property. I changed the behavior to return a list of the PRESET_HOLD and PRESET_HOME preset constants, plus changed the update function to return the PRESET_HOME if the hold status is not True.

These changes fixed an issue I was having synchronizing the entity to the Google Assistant service through Nabu Casa. 